### PR TITLE
Always suppress compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,15 @@ Security in case of vulnerabilities.
   {meth}`snek5000.output.base.Output.get_path_solver_package`).
 - {meth}`snek5000.output.base.Output.get_configfile` (use a string `"config_simul.yml"`
   instead in user Snakefile).
+- The ``warnings`` parameter in
+  {meth}`snek5000.output.base.Output.update_snakemake_config` is deprecated!
+  Use `verbosity=0` (now default) to disable warnings.
+
+### Removed
+
+- Parameter `warnings` in {func}`snek5000.util.smake.append_debug_flags` is
+  replaced by a separate function
+  {func}`snek5000.util.smake.set_compiler_verbosity`.
 
 ### Fixed
 

--- a/docs/ipynb/executed/tuto_simul_exec.ipynb
+++ b/docs/ipynb/executed/tuto_simul_exec.ipynb
@@ -462,7 +462,7 @@
     "The equivalent of this in the shell command line would be ``export\n",
     "SNEK_DEBUG=1``. By doing so, snek5000 would:\n",
     "\n",
-    "- suppress the compiler warnings in the Nek5000 core source code. See {func}`snek5000.util.smake.append_debug_flags`\n",
+    "- perform stricter compile time checks. See {func}`snek5000.util.smake.append_debug_flags`\n",
     "- activate the code blocks under the preprocessing flag in Fortran sources `#ifdef DEBUG`\n"
    ]
   },

--- a/src/snek5000/operators.py
+++ b/src/snek5000/operators.py
@@ -40,7 +40,7 @@ def next_power(value, base=2):
 
     """
     exponent = math.ceil(math.log(value, base))
-    return base ** exponent
+    return base**exponent
 
 
 class Operators:

--- a/src/snek5000/util/smake.py
+++ b/src/snek5000/util/smake.py
@@ -18,7 +18,25 @@ def ensure_env():
         os.environ["PATH"] = ":".join([NEK_SOURCE_ROOT + "/bin", os.getenv("PATH")])
 
 
-def append_debug_flags(config, warnings):
+def set_compiler_verbosity(config, verbosity):
+    """Set Fortran compiler warnings verbosity:
+
+    Parameters
+    ----------
+    config: dict
+    verbosity: int
+        - 0 == suppress warnings
+        - 1 == do nothing
+        - 2 == all warnings
+
+    """
+    flags = {0: " -w ", 1: "", 2: " -Wall "}
+    warning_flag = flags[int(verbosity)]
+    config["FFLAGS"] = config.get("FFLAGS", "") + warning_flag
+    config["CFLAGS"] = config.get("CFLAGS", "") + warning_flag
+
+
+def append_debug_flags(config):
     """Append to commonly used gcc / gfortran debug flags if ``SNEK_DEBUG``
     environment is activated.
 
@@ -26,15 +44,11 @@ def append_debug_flags(config, warnings):
     ----------
     config: dict
         Snakemake configuration. Should contain ``CFLAGS`` and ``FFLAGS`` keys.
-    warnings: bool
-        Show most compiler warnings or suppress them.
 
     """
-    warnings_option = "-Wall" if warnings else "-w"
     if os.getenv("SNEK_DEBUG"):
         config["CFLAGS"] = config.get("CFLAGS", "") + " -O0 -g"
         config["FFLAGS"] = (
             config.get("FFLAGS", "")
             + " -O0 -g -ffpe-trap=invalid,zero,overflow -DDEBUG "
-            + warnings_option
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,11 @@ from collections import defaultdict
 
 import pytest
 
-from snek5000.util.smake import append_debug_flags, ensure_env
+from snek5000.util.smake import (
+    append_debug_flags,
+    ensure_env,
+    set_compiler_verbosity,
+)
 
 
 def test_ensure_env():
@@ -18,17 +22,30 @@ def test_ensure_env():
     assert shutil.which("makenek"), "Nek5000/bin is not included in the PATH"
 
 
+@pytest.mark.parametrize("verbosity", (0, 1, 2))
+def test_verbosity(verbosity):
+    config = defaultdict(str)
+    set_compiler_verbosity(config, verbosity)
+    if not verbosity:
+        assert " -w " in config["FFLAGS"]
+        assert " -w " in config["CFLAGS"]
+    elif verbosity == 1:
+        assert " -w " not in config["FFLAGS"]
+        assert " -w " not in config["CFLAGS"]
+        assert " -Wall " not in config["FFLAGS"]
+        assert " -Wall " not in config["CFLAGS"]
+    elif verbosity == 2:
+        assert " -Wall " in config["FFLAGS"]
+        assert " -Wall " in config["CFLAGS"]
+
+
 @pytest.mark.parametrize("warnings", (True, False))
 def test_debug_flags(warnings):
     debug_state = os.getenv("SNEK_DEBUG", "")
     os.environ["SNEK_DEBUG"] = "1"
 
     config = defaultdict(str)
-    append_debug_flags(config, warnings)
-    if warnings:
-        assert "-Wall" in config["FFLAGS"]
-    else:
-        assert "-w" in config["FFLAGS"]
+    append_debug_flags(config)
 
     assert all("-O0 -g" in config[k] for k in ("CFLAGS", "FFLAGS"))
 


### PR DESCRIPTION
Fixes #145 
Set compiler verbosity=0 (default) using a new keyword-only parameter
