### PR TITLE
Try to simplify code for running the tutorial scripts

### DIFF
--- a/docs/tuto_cbox.md
+++ b/docs/tuto_cbox.md
@@ -36,16 +36,17 @@ In normal life, we would just execute this script with something like
 `python tuto_cbox.py`. However, in this notebook, we need a bit more code:
 
 ```{code-cell}
-from pathlib import Path
-import subprocess
-import sys
+from subprocess import run, PIPE, STDOUT
+from time import perf_counter
 
-path_script = Path.cwd() / "examples/scripts/tuto_cbox.py"
-print(f"Running the script {path_script.name}... (It can take few minutes.)")
-process = subprocess.run(
-    [sys.executable, str(path_script)], check=True, text=True,
-    stdout=subprocess.PIPE,  stderr=subprocess.STDOUT
+command = "python3 examples/scripts/tuto_cbox.py"
+
+print("Running the script tuto_box.py... (It can take few minutes.)")
+t_start = perf_counter()
+process = run(
+    command.split(), check=True, text=True, stdout=PIPE,  stderr=STDOUT
 )
+print(f"Script executed in {perf_counter() - t_start:.2f} s")
 ```
 
 The script has now been executed. Let's look at its output.

--- a/docs/tuto_phill.md
+++ b/docs/tuto_phill.md
@@ -103,16 +103,17 @@ In normal life, we would just execute this script with something like
 `python tuto_phill.py`. However, in this notebook, we need a bit more code:
 
 ```{code-cell}
-from pathlib import Path
-import subprocess
-import sys
+from subprocess import run, PIPE, STDOUT
+from time import perf_counter
 
-path_script = Path.cwd() / "examples/scripts/tuto_phill.py"
-print(f"Running the script {path_script.name}... (It can take few minutes.)")
-process = subprocess.run(
-    [sys.executable, str(path_script)], check=True, text=True,
-    stdout=subprocess.PIPE,  stderr=subprocess.STDOUT
+command = "python3 examples/scripts/tuto_phill.py"
+
+print("Running the script tuto_phill.py... (It can take few minutes.)")
+t_start = perf_counter()
+process = run(
+    command.split(), check=True, text=True, stdout=PIPE,  stderr=STDOUT
 )
+print(f"Script executed in {perf_counter() - t_start:.2f} s")
 ```
 
 The simulation is done! Let's look at its output:

--- a/docs/tuto_tgv.md
+++ b/docs/tuto_tgv.md
@@ -32,16 +32,17 @@ In normal life, we would just execute this script with something like
 `python tuto_tgv.py`. However, in this notebook, we need a bit more code:
 
 ```{code-cell}
-from pathlib import Path
-import subprocess
-import sys
+from subprocess import run, PIPE, STDOUT
+from time import perf_counter
 
-path_script = Path.cwd() / "examples/scripts/tuto_tgv.py"
-print(f"Running the script {path_script.name}... (It can take few minutes.)")
-process = subprocess.run(
-    [sys.executable, str(path_script)], check=True, text=True,
-    stdout=subprocess.PIPE,  stderr=subprocess.STDOUT
+command = "python3 examples/scripts/tuto_tgv.py"
+
+print("Running the script tuto_tgv.py... (It can take few minutes.)")
+t_start = perf_counter()
+process = run(
+    command.split(), check=True, text=True, stdout=PIPE,  stderr=STDOUT
 )
+print(f"Script executed in {perf_counter() - t_start:.2f} s")
 ```
 
 The script has now been executed. Let's look at its output:


### PR DESCRIPTION
Related to #169

There are two issues with Ipython magic execution:

- It starts a new shell and the result includes stdout written at the initialization of the shell.
- Potential errors are just ignored (so we would have to add code to detect issues).

```
In [1]: result = !python -c "raise Exception"

In [2]: result
Out[2]: 
['Traceback (most recent call last):',
 '  File "<string>", line 1, in <module>',
 'Exception']
```

Considering these problems, I think explicit is better than implicit and that the call of `subprocess.run` is not so bad.

In this PR, I simplify the code. No need for `Path` and `sys.executable` (even if just calling `python3` may be buggy on some environments)...