### PR TITLE
Delete .gitmodules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
 
 env:
   FORCE_COLOR: 1
+  NEK_SOURCE_ROOT: /home/runner/Nek5000
 
 jobs:
   tests:
@@ -25,8 +26,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        submodules: recursive
         fetch-depth: 0
+
+    - name: Clone Nek5000
+      run: git clone --depth=1 https://github.com/snek5000/Nek5000.git $HOME/Nek5000
 
     - name: Install apt packages
       run: |
@@ -101,8 +104,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        submodules: recursive
         fetch-depth: 0
+
+    - name: Clone Nek5000
+      run: git clone --depth=1 https://github.com/snek5000/Nek5000.git $HOME/Nek5000
 
     - name: Install apt packages
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
 
 env:
   FORCE_COLOR: 1
+  NEK_SOURCE_ROOT: /home/runner/Nek5000
 
 jobs:
   pypi:
@@ -14,7 +15,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        submodules: recursive
+
+    - name: Clone Nek5000
+      run: git clone --depth=1 https://github.com/snek5000/Nek5000.git $HOME/Nek5000
 
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "lib/Nek5000"]
-	path = lib/Nek5000
-	url = https://github.com/snek5000/Nek5000.git
-	ignore = dirty

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,14 @@
 version: 2
 
-# VCS submodules configuration
-submodules:
-  include: all
-  recursive: true
-
 build:
   apt_packages:
     - build-essential
     - gfortran
     - libopenmpi-dev
+  jobs:
+    pre_create_environment:
+      - git clone --depth=1 https://github.com/snek5000/Nek5000.git $HOME/Nek5000
+      - export NEK_SOURCE_ROOT=$HOME/Nek5000
 
 # Optionally set the version of Python and requirements required to build your
 # docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,4 +83,4 @@ set secure exrc
 ```
 
 This sources the `.exrc` file which comes along with the repository and enables syntax
-highlighting for file extensions used in `lib/Nek5000`.
+highlighting for file extensions used in `Nek5000`.

--- a/activate.sh
+++ b/activate.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 DIR="$(pwd)"
-export NEK_SOURCE_ROOT="$DIR/lib/Nek5000"
 export PATH="$PATH:$NEK_SOURCE_ROOT/bin"
 
 alias smake="snakemake -j all"

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -869,7 +869,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = .. \
-                         ../lib/Nek5000/core
+                         $(NEK_SOURCE_ROOT)/core
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -956,7 +956,7 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../lib/Nek5000/core/makenek.inc
+EXCLUDE                = $(NEK_SOURCE_ROOT)/core/makenek.inc
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,12 +47,9 @@ sys.path.insert(0, root(breathe))
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, root(snek5000))
-os.environ["NEK_SOURCE_ROOT"] = os.fspath(
-    (Path(__file__).parent.parent / "lib" / "Nek5000").resolve()
-)
 
-
-print("NEK_SOURCE_ROOT = ", snek5000.get_nek_source_root())
+NEK_SOURCE_ROOT = snek5000.get_nek_source_root()
+print("NEK_SOURCE_ROOT = ", NEK_SOURCE_ROOT)
 print("sys.path =\n   ", "\n    ".join(sys.path))
 
 # -- Project information -----------------------------------------------------
@@ -125,7 +122,7 @@ source_suffix = {
 os.makedirs("_build/html/doxygen", exist_ok=True)
 
 # Inspect whether to run doxygen or not
-last_modified = util.last_modified("../lib").stat().st_mtime
+last_modified = util.last_modified(NEK_SOURCE_ROOT).stat().st_mtime
 timestamp = Path("_build/.doxygen_timestamp")
 if timestamp.exists() and Path("_build/xml").exists():
     with open(timestamp) as fp:

--- a/docs/examples/scripts/tuto_phill.py
+++ b/docs/examples/scripts/tuto_phill.py
@@ -1,4 +1,4 @@
-import os
+# import os
 
 from phill.solver import Simul
 
@@ -7,7 +7,7 @@ params.output.sub_directory = "examples_snek/tuto"
 params.oper.nx = 6
 params.oper.ny = 5
 params.oper.nz = 4
-params.oper.elem.order = params.oper.elem.order_out = 10
+params.oper.elem.order = params.oper.elem.order_out = 8
 
 params.oper.nproc_min = 2
 
@@ -20,6 +20,6 @@ params.nek.stat.io_step = 10
 
 sim = Simul(params)
 
-os.environ["SNEK_DEBUG"] = "1"
+# os.environ["SNEK_DEBUG"] = "1"
 
 sim.make.exec("run_fg", nproc=2)

--- a/docs/ls_no_extensions.py
+++ b/docs/ls_no_extensions.py
@@ -1,5 +1,11 @@
 """List files with no extensions"""
+import os
 from pathlib import Path
+
+try:
+    NEK_SOURCE_ROOT = Path(os.environ["NEK_SOURCE_ROOT"])
+except KeyError:
+    raise RuntimeError("NEK_SOURCE_ROOT has to be defined")
 
 
 def is_upper(name):
@@ -15,8 +21,8 @@ def ls_no_ext(root, suffix="", prefix=""):
 
 if __name__ == "__main__":
     # For doxygen
-    ls_no_ext("../lib/Nek5000/core", " " * 25, " \\")
+    ls_no_ext(NEK_SOURCE_ROOT / "core", " " * 25, " \\")
     ls_no_ext("../src/abl/toolbox", " " * 25, " \\")
 
     # For vim
-    # ls_no_ext("../lib/Nek5000/core", " "*12 + "\\ ", ",")
+    # ls_no_ext(NEK_SOURCE_ROOT / "core", " "*12 + "\\ ", ",")

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,8 +33,13 @@ else:
     BUILD_SYSTEM = "setuptools"
     PACKAGE_SPEC = "setup.cfg"
 
+try:
+    NEK_SOURCE_ROOT = os.environ["NEK_SOURCE_ROOT"]
+except KeyError:
+    raise RuntimeError("NEK_SOURCE_ROOT has point to Nek5000 top level directory.")
+
 TEST_ENV_VARS = {
-    "NEK_SOURCE_ROOT": str(CWD / "lib" / "Nek5000"),
+    "NEK_SOURCE_ROOT": NEK_SOURCE_ROOT,
     "SNEK_DEBUG": "1",
 }
 if os.getenv("CI"):
@@ -270,7 +275,7 @@ def docs_autobuild(session):
 def ctags(session):
     """Runs universal-ctags to build .tags file"""
     sources = {
-        "nek5000": "lib/Nek5000/core",
+        "nek5000": str(Path(NEK_SOURCE_ROOT) / "core"),
         "snek5000": "src/snek5000",
     }
     output = ".tags"

--- a/src/snek5000/__init__.py
+++ b/src/snek5000/__init__.py
@@ -33,6 +33,7 @@ from importlib import resources as _resources
 import os
 from warnings import warn
 import weakref
+from pathlib import Path
 
 from fluiddyn.util import mpi  # noqa: F401
 
@@ -49,14 +50,15 @@ def get_nek_source_root():
             "SOURCE_ROOT is deprecated in v19, use NEK_SOURCE_ROOT instead."
         )
 
-    with _resources.path(__name__, "__init__.py") as f:
-        root = f.parent
-
-    nek5000 = os.path.expandvars(
-        os.path.expanduser(
-            os.getenv("NEK_SOURCE_ROOT", str((root / "../../lib/Nek5000").absolute()))
+    try:
+        NEK_SOURCE_ROOT = os.environ["NEK_SOURCE_ROOT"]
+    except KeyError:
+        raise RuntimeError(
+            "NEK_SOURCE_ROOT has to point to Nek5000 top level directory."
         )
-    )
+
+    nek5000 = str(Path(os.path.expandvars(NEK_SOURCE_ROOT)).expanduser().absolute())
+
     if not os.path.exists(nek5000):
         logger.error("NEK_SOURCE_ROOT: " + nek5000)
         raise IOError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,9 +145,10 @@ def sim_executed():
     params.oper.nproc_min = 2
     params.oper.nproc_max = 12
     params.oper.nx = params.oper.ny = params.oper.nz = 3
+    params.oper.elem.order = params.oper.elem.order_out = 8
 
-    params.nek.stat.av_step = 4
-    params.nek.stat.io_step = 8
+    params.nek.stat.av_step = 2
+    params.nek.stat.io_step = 4
 
     sim = Simul(params)
     assert sim.make.exec("run_fg"), "phill simulation failed"

--- a/tests/test_sim_executed.py
+++ b/tests/test_sim_executed.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.slow
+def test_sim_phillexecuted(sim_executed):
+    pass
+
+
+@pytest.mark.slow
+def test_sim_cbox_executed(sim_cbox_executed):
+    pass


### PR DESCRIPTION
Having .gitmodules with a repo that changed in time create issues with hg + hg-git. It is also much better for the developers to be in the same situation than the users (i.e. without lib/Nek5000).

We now assume than the environment variable `NEK_SOURCE_ROOT` is defined and points to Nek5000 top level directory.